### PR TITLE
fix: handle absence of read perm on product_serial

### DIFF
--- a/src/boot.sh
+++ b/src/boot.sh
@@ -116,7 +116,7 @@ fi
 
 SM_BIOS=""
 
-if [ -s "/sys/class/dmi/id/product_serial" ]; then
+if [ -s "/sys/class/dmi/id/product_serial" && -r "/sys/class/dmi/id/product_serial" ]; then
 
   BIOS_SERIAL=$(</sys/class/dmi/id/product_serial)
   BIOS_SERIAL="${BIOS_SERIAL//[![:alnum:]]/}"


### PR DESCRIPTION
`/sys/class/dmi/id/product_serial` can exist, be non-empty, but configured in a way that podman cannot read it.

This patch proposes to check read permission before using this file.