### PR TITLE
Adding support for boss linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,7 @@ kubectl apply -f https://raw.githubusercontent.com/qemus/qemu/refs/heads/master/
   | `alma`     | Alma Linux      | 2.2 GB  |
   | `alpine`   | Alpine Linux    | 60 MB   |
   | `arch`     | Arch Linux      | 1.2 GB  |
+  | `boss`     | Boss 10 Desktop | 2.5 GB  |
   | `cachy`    | CachyOS         | 2.6 GB  |
   | `centos`   | CentOS          | 7.0 GB  |
   | `debian`   | Debian          | 3.3 GB  |

--- a/src/define.sh
+++ b/src/define.sh
@@ -49,6 +49,11 @@ getURL() {
       if [[ "$ret" == "url" ]]; then
         url="https://geo.mirror.pkgbuild.com/iso/latest/archlinux-x86_64.iso"
       fi ;;
+    "boss" | "boss-desktop" | "boss-linux" )
+      name="Boss 10 Desktop linux"
+      if [[ "$ret" == "url" ]]; then
+        url="https://bosslinux.in/sites/default/files/ISOImages/BOSS-10.0-DE-amd64-DVD.iso"
+      fi ;;
     "cachy" | "cachyos" )
       name="CachyOS"
       if [[ "$ret" == "url" ]]; then


### PR DESCRIPTION
- Boss Desktop 10 linux is customized to suit India's digital environment. 
- It supports most of the Indian languages.