### PR TITLE
compose.yml: allow BOOT set at build time

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@ services:
     image: qemux/qemu
     container_name: qemu
     environment:
-      BOOT: "alpine"
+      BOOT: ${BOOT-alpine}
     devices:
       - /dev/kvm
       - /dev/net/tun


### PR DESCRIPTION
E.g.:
```console
$ BOOT="https://download.fedoraproject.org/pub/alt/iot/42/IoT/x86_64/iso/Fedora-IoT-ostree-42-20250414.0.x86_64.iso" podman-compose up ...
```