### PR TITLE
Update reset.sh to fix "TO: command not found"

### DIFF
--- a/src/reset.sh
+++ b/src/reset.sh
@@ -100,8 +100,7 @@ FS=$(echo "$FS" | sed 's/[)(]//g')
 SPACE=$(df --output=avail -B 1 "$STORAGE" | tail -n 1)
 SPACE_GB=$(formatBytes "$SPACE" "down")
 AVAIL_MEM=$(formatBytes "$RAM_AVAIL" "down")
-TO
-TAL_MEM=$(formatBytes "$RAM_TOTAL" "up")
+TOTAL_MEM=$(formatBytes "$RAM_TOTAL" "up")
 
 echo "❯ CPU: ${CPU} | RAM: ${AVAIL_MEM/ GB/}/$TOTAL_MEM | DISK: $SPACE_GB (${FS}) | KERNEL: ${SYS}..."
 echo


### PR DESCRIPTION
Fixing "TO: command not found" and "TOTAL_MEM: unbound variable" introduced in https://github.com/qemus/qemu/commit/6e498a2b68f6a4b08369b76a76b1ec9b38f20847#diff-34c05c7672ccce45ea92384aaf65633fcf4578043b9af920acad3748fe17e0baR103-R104