### PR TITLE
feat: Do not require IP in DHCP mode

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -644,12 +644,17 @@ getInfo() {
   fi
 
   GATEWAY=$(ip route list dev "$VM_NET_DEV" | awk ' /^default/ {print $3}' | head -n 1)
-  IP=$(ip address show dev "$VM_NET_DEV" | grep inet | awk '/inet / { print $2 }' | cut -f1 -d/ | head -n 1) || IP=""
-  IP6=""
+  { IP=$(ip address show dev "$VM_NET_DEV" | grep inet | awk '/inet / { print $2 }' | cut -f1 -d/ | head -n 1); rc=$?; } 2>/dev/null || :
 
+  if (( rc != 0 )) && [[ "$DHCP" != [Yy1]* ]]; then
+    error "Could not determine container IP address!" && exit 26
+  fi
+
+  IP6=""
   # shellcheck disable=SC2143
   if [ -f /proc/net/if_inet6 ] && [ -n "$(ifconfig -a | grep inet6)" ]; then
-    IP6=$(ip -6 addr show dev "$VM_NET_DEV" scope global up)
+    { IP6=$(ip -6 addr show dev "$VM_NET_DEV" scope global up); rc=$?; } 2>/dev/null || :
+    (( rc != 0 )) && IP6=""
     [ -n "$IP6" ] && IP6=$(echo "$IP6" | sed -e's/^.*inet6 \([^ ]*\)\/.*$/\1/;t;d' | head -n 1)
   fi
 


### PR DESCRIPTION
In CNI, MACVLAN can be used only as a Layer 2 network without assigning an IP address. In this case, the container will not be assigned an IP address, but the VM will obtain an IP address using DHCP. Therefore, it is necessary to allow the IP address to be empty.