### PR TITLE
Add SPICE protocol support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN set -eu && \
         inotify-tools \
         netcat-openbsd \
         ca-certificates \
-        qemu-system-x86 && \
+        qemu-system-x86 \
+        qemu-system-modules-spice && \
     wget "https://github.com/qemus/passt/releases/download/v${VERSION_PASST}/passt_${VERSION_PASST}_${TARGETARCH}.deb" -O /tmp/passt.deb -q && \
     dpkg -i /tmp/passt.deb && \
     apt-get clean && \


### PR DESCRIPTION
# Add SPICE Protocol Support

## Summary

This PR adds the `qemu-system-modules-spice` package to enable SPICE protocol support in the QEMU base image, addressing a critical requirement for GPU passthrough use cases with Looking Glass.

## Problem

Currently, users attempting to use SPICE with containers based on this image encounter errors:

```
ERROR: qemu-system-x86_64: -spice unix=on,addr=/tmp/spice.sock,disable-ticketing: There is no option group 'spice'
qemu-system-x86_64: Perhaps you want to install qemu-system-modules-spice package?
```

This limitation blocks an important use case that depends on this base image:

### GPU Passthrough + Looking Glass Integration

Looking Glass is a popular open-source solution for GPU passthrough that provides near-native graphics performance in virtual machines. According to the [official Looking Glass B7 installation guide](https://looking-glass.io/docs/B7/install_libvirt/#keyboard-mouse-display-audio):

> **"Looking Glass makes use of the SPICE protocol to provide keyboard and mouse input, audio input and output, and display fallback."**

The documentation is explicit: **without SPICE, you cannot send keyboard/mouse events to the guest**. This makes SPICE an **essential requirement** (not optional) for GPU passthrough setups using Looking Glass, particularly for:
- Anti-cheat compatible gaming (Looking Glass doesn't trigger anti-cheat systems)
- Ultra-low latency display with proper input handling
- Modern Wayland/compositor environments (SPICE provides relative mouse mode required by Looking Glass)
- Audio input/output via SPICE agent

## Solution

The fix is a single line addition: install `qemu-system-modules-spice` alongside existing dependencies. This enables QEMU's `-spice` option without affecting any existing functionality.

```dockerfile
qemu-system-x86 \
qemu-system-modules-spice && \
```

## Use Cases Enabled

This change enables downstream projects (like dockurr/windows and others) to:

1. **Support GPU passthrough workflows** - Integrate Looking Glass for gaming VMs with proper input handling via SPICE

## Impact

- ✅ **Backward compatible** - Simply adds an optional package; existing functionality unchanged
- ✅ **Widely tested** - SPICE module has been successfully used in community builds
- ✅ **Addresses real user needs** - Multiple downstream projects require this capability

## Context

This change benefits all downstream projects that build on qemux/qemu by enabling SPICE support at the base layer, rather than requiring each project to add it separately.

## Testing

The SPICE module has been tested successfully with:
- GPU passthrough + Looking Glass configurations
- SPICE socket connectivity (`unix=on,addr=/tmp/spice.sock`)
- Input device handling (mouse, keyboard via SPICE agent)
- Audio routing via SPICE

## Note on SPICE Deprecation

While SPICE development has slowed, it remains:
- **Actively maintained** in Debian/Ubuntu repositories
- **Essential** for Looking Glass (no alternative exists)
- **Required** by a significant user base for GPU passthrough use cases

Including this module keeps the base image flexible for users who need SPICE, while not impacting those who don't.

---

This single-line change unblocks an important class of GPU passthrough use cases while maintaining the project's clean architecture and minimal footprint.