### PR TITLE
fix: Correct MX Linux version parsing for ISO download

### DIFF
--- a/src/define.sh
+++ b/src/define.sh
@@ -134,7 +134,7 @@ getURL() {
     "mx" | "mxlinux" | "mx-linux" )
       name="MX Linux"
       if [[ "$ret" == "url" ]]; then
-        version=$(curl --disable -Ils "https://sourceforge.net/projects/mx-linux/files/latest/download" | grep -i 'location:' | cut -d? -f1 | cut -d_ -f1 | cut -d- -f3) || exit 65
+        version=$(curl --disable -Ils "https://sourceforge.net/projects/mx-linux/files/latest/download" | grep -i 'location:' | cut -d? -f1 | cut -d_ -f1-2 | cut -d- -f3) || exit 65
         url="https://mirror.umd.edu/mxlinux-iso/MX/Final/Xfce/MX-${version}_x64.iso"
       fi ;;
     "nixos" )


### PR DESCRIPTION
Fixes #989

This PR fixes the MX Linux ISO download logic.

The current parsing extracts only the major version number (e.g., `25`), which
results in an invalid ISO filename being constructed:

    MX-25_x64.iso

However, the actual ISO filename includes the desktop environment suffix, such as:

    MX-25_Xfce_x64.iso

Because of this mismatch, the container continuously fails to download MX Linux.

### Fix
Updated the version parsing logic in `define.sh` to extract the correct
version string from the SourceForge redirect URL:

    version=$(curl ... | cut -d_ -f1-2 | cut -d- -f3)

This produces the correct format (e.g., `25_Xfce`), resulting in a valid URL:

    https://mirror.umd.edu/mxlinux-iso/MX/Final/Xfce/MX-25_Xfce_x64.iso

### Result
The container now downloads the correct ISO instead of failing repeatedly.