### PR TITLE
fix: Select iptables backend by probing instead of /proc/modules

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -538,7 +538,7 @@ configureNAT() {
     warn "failed to set master bridge!" && return 1
   fi
 
-  if grep -wq "nf_tables" /proc/modules; then
+  if command -v iptables-nft >/dev/null 2>&1 && iptables-nft -V >/dev/null 2>&1; then
     update-alternatives --set iptables /usr/sbin/iptables-nft > /dev/null
     update-alternatives --set ip6tables /usr/sbin/ip6tables-nft > /dev/null
   else


### PR DESCRIPTION
This PR fixes iptables backend detection during NAT network setup.

The current logic checks for nf_tables in /proc/modules to decide between
iptables-nft and iptables-legacy. On modern systems, nf_tables is often
built into the kernel or hidden in containerized environments, causing the check
to fail.

Replace the /proc/modules check with capability probing by detecting the
presence of iptables-nft and preferring it when available.