### PR TITLE
fix: MASQUERADE every attached network in NAT mode

### DIFF
--- a/examples/multi-network-bug/01-single-network/compose.yml
+++ b/examples/multi-network-bug/01-single-network/compose.yml
@@ -1,0 +1,15 @@
+services:
+  qemu:
+    image: ${IMAGE:-qemux/qemu}
+    container_name: qemu-multinet-repro
+    environment:
+      BOOT: "alpine"
+      DEBUG: "Y"
+    devices:
+      - /dev/kvm
+      - /dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "8006:8006"
+    stop_grace_period: 2m

--- a/examples/multi-network-bug/02-external-network/compose.yml
+++ b/examples/multi-network-bug/02-external-network/compose.yml
@@ -1,0 +1,21 @@
+services:
+  qemu:
+    image: ${IMAGE:-qemux/qemu}
+    container_name: qemu-multinet-repro
+    environment:
+      BOOT: "alpine"
+      DEBUG: "Y"
+    devices:
+      - /dev/kvm
+      - /dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "8006:8006"
+    stop_grace_period: 2m
+    networks:
+      - netA
+
+networks:
+  netA:
+    external: true

--- a/examples/multi-network-bug/03-two-networks/compose.yml
+++ b/examples/multi-network-bug/03-two-networks/compose.yml
@@ -1,0 +1,30 @@
+services:
+  qemu:
+    image: ${IMAGE:-qemux/qemu}
+    container_name: qemu-multinet-repro
+    environment:
+      BOOT: "alpine"
+      DEBUG: "Y"
+    devices:
+      - /dev/kvm
+      - /dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - "8006:8006"
+    stop_grace_period: 2m
+    networks:
+      - netA
+      - netB
+
+networks:
+  netA:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  netB:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.29.0.0/24

--- a/examples/multi-network-bug/README.md
+++ b/examples/multi-network-bug/README.md
@@ -1,0 +1,52 @@
+# Multi-network reproduction
+
+Minimal reproduction of the bug where a QEMU VM started by `qemux/qemu` loses
+network access once the host container is attached to more than one Docker
+network.
+
+## Layout
+
+| Case                  | Attached networks          | Expected today       |
+| --------------------- | -------------------------- | -------------------- |
+| `01-single-network`   | default bridge only        | VM has network       |
+| `02-external-network` | one externally-created net | VM has network       |
+| `03-two-networks`     | two user-defined bridges   | VM has **no** network |
+
+All three compose files use `BOOT=alpine` (smallest auto-downloaded ISO,
+~60 MB) and `DEBUG=Y` so `getInfo()` in `src/network.sh` prints the detected
+interface to the container logs.
+
+## Prerequisites
+
+- Docker Engine with Compose v2
+- Host with `/dev/kvm` and `/dev/net/tun`
+- `NET_ADMIN` capability available to the container (default for root Docker)
+
+## Running
+
+```sh
+./verify.sh 01-single-network
+./verify.sh 02-external-network
+./verify.sh 03-two-networks
+```
+
+`verify.sh` brings up the compose file, waits for in-container networking to
+initialise, then checks:
+
+1. Which container interface `getInfo()` picked (parsed from the logs).
+2. Whether that interface holds the default route inside the container.
+3. Whether a `MASQUERADE` rule exists on the detected interface.
+4. Whether every external container interface (not `lo`, not the internal
+   `docker` bridge, not the `qemu` tap) has a `MASQUERADE` rule.
+
+The script exits 0 on all-pass, 1 otherwise, and always cleans up the
+container. With the current `src/network.sh`, case `03-two-networks` fails
+check #4 because `configureNAT()` only installs MASQUERADE on the single
+interface `getInfo()` picked — any VM traffic routed through the other
+attached network leaves un-NATed and dies on the host.
+
+The script deliberately does **not** depend on the guest booting far enough
+to DHCP or generate egress, because `BOOT=alpine` drops to a login prompt
+rather than configuring networking automatically. The iptables /
+interface-level checks reveal the misconfiguration directly, which is where
+the defect lives.

--- a/examples/multi-network-bug/verify.sh
+++ b/examples/multi-network-bug/verify.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# verify.sh — reproduce & verify the "VM loses network when container has
+# multiple Docker networks" behaviour of qemus/qemu.
+#
+# Usage: ./verify.sh <case-dir>
+#   where <case-dir> is one of: 01-single-network, 02-external-network,
+#                               03-two-networks
+#
+# The script brings up the compose file under <case-dir>, waits for the
+# container's network setup to finish and for the VM to DHCP, then collects
+# host-side signals via `docker exec` / `docker logs` and prints a PASS/FAIL
+# summary.
+#
+# Requires: docker, docker compose, a host with KVM + /dev/net/tun.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+CONTAINER="qemu-multinet-repro"
+
+die() { echo "ERROR: $*" >&2; exit 2; }
+note() { echo "--- $* ---"; }
+pass() { echo "PASS: $*"; PASSES=$((PASSES + 1)); }
+fail() { echo "FAIL: $*"; FAILURES=$((FAILURES + 1)); }
+
+PASSES=0
+FAILURES=0
+
+[ $# -eq 1 ] || die "expected exactly one arg (case directory)"
+CASE_DIR="$SCRIPT_DIR/$1"
+[ -f "$CASE_DIR/compose.yml" ] || die "$CASE_DIR/compose.yml not found"
+
+# shellcheck disable=SC2329  # invoked via trap
+CREATED_EXTERNAL_NETA=0
+
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    local rc=$?
+    note "cleanup"
+    docker compose -f "$CASE_DIR/compose.yml" down --remove-orphans --timeout 5 \
+        > /dev/null 2>&1 || true
+    if [ "$CREATED_EXTERNAL_NETA" = 1 ]; then
+        docker network rm netA > /dev/null 2>&1 || true
+    fi
+    exit "$rc"
+}
+trap cleanup EXIT
+
+if [ "$1" = "02-external-network" ]; then
+    if ! docker network inspect netA > /dev/null 2>&1; then
+        note "creating external network netA (172.28.0.0/24)"
+        docker network create --subnet 172.28.0.0/24 netA > /dev/null
+        CREATED_EXTERNAL_NETA=1
+    fi
+fi
+
+note "docker compose up -d ($1)"
+docker compose -f "$CASE_DIR/compose.yml" down --remove-orphans --timeout 5 \
+    > /dev/null 2>&1 || true
+docker compose -f "$CASE_DIR/compose.yml" up -d > /dev/null
+
+note "waiting for container networking to initialise"
+for _ in $(seq 1 60); do
+    if docker exec "$CONTAINER" pgrep -x dnsmasq > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+docker exec "$CONTAINER" pgrep -x dnsmasq > /dev/null 2>&1 \
+    || { docker logs --tail 80 "$CONTAINER" || true; die "dnsmasq never started inside the container"; }
+
+note "container interfaces"
+docker exec "$CONTAINER" ip -br addr || true
+
+note "container routes"
+docker exec "$CONTAINER" ip route || true
+
+note "container NAT rules"
+docker exec "$CONTAINER" iptables -t nat -S POSTROUTING || true
+echo
+docker exec "$CONTAINER" iptables -t nat -S PREROUTING || true
+
+note "getInfo() debug line from container logs"
+# strip ANSI escapes; accept any (or zero) chars before "Host:"
+DEBUG_LINE=$(docker logs "$CONTAINER" 2>&1 \
+    | sed -r 's/\x1b\[[0-9;]*[A-Za-z]//g' \
+    | grep -E 'Host:.*Interface:' | tail -n 1 || true)
+echo "$DEBUG_LINE"
+
+DETECTED_IF=$(echo "$DEBUG_LINE" | sed -n 's/.*Interface: \([^ ]*\).*/\1/p')
+
+DEFAULT_IF=$(docker exec "$CONTAINER" ip -o -4 route show default \
+    | awk '{print $5; exit}')
+
+BRIDGE_IFS=$(docker exec "$CONTAINER" ip -o -4 addr show scope global \
+    | awk '{print $2}' | sort -u | grep -Ev '^(lo|docker|qemu)$' || true)
+
+note "checks"
+
+if [ -n "$DETECTED_IF" ]; then
+    pass "getInfo() picked an interface ($DETECTED_IF)"
+else
+    fail "getInfo() did not emit a recognisable Interface: line"
+fi
+
+if [ -n "$DETECTED_IF" ] && [ -n "$DEFAULT_IF" ] && [ "$DETECTED_IF" = "$DEFAULT_IF" ]; then
+    pass "detected interface ($DETECTED_IF) holds the default route"
+else
+    fail "detected interface is '$DETECTED_IF' but default route is on '$DEFAULT_IF'"
+fi
+
+if docker exec "$CONTAINER" iptables -t nat -S POSTROUTING \
+    | grep -qE -- "-A POSTROUTING -o $DETECTED_IF -j MASQUERADE"; then
+    pass "MASQUERADE rule present on detected interface ($DETECTED_IF)"
+else
+    fail "MASQUERADE rule missing on detected interface ($DETECTED_IF)"
+fi
+
+MISSING_MASQ=()
+while read -r iface; do
+    [ -n "$iface" ] || continue
+    if ! docker exec "$CONTAINER" iptables -t nat -S POSTROUTING \
+        | grep -qE -- "-A POSTROUTING -o $iface -j MASQUERADE"; then
+        MISSING_MASQ+=("$iface")
+    fi
+done <<< "$BRIDGE_IFS"
+
+if [ ${#MISSING_MASQ[@]} -eq 0 ]; then
+    pass "every external container interface has a MASQUERADE rule"
+else
+    fail "no MASQUERADE rule on: ${MISSING_MASQ[*]} (VM traffic routed via these will leak un-NATed)"
+fi
+
+note "summary for case $1"
+echo "passes:   $PASSES"
+echo "failures: $FAILURES"
+
+if [ "$FAILURES" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/src/network.sh
+++ b/src/network.sh
@@ -563,6 +563,22 @@ configureNAT() {
     fi
   fi
 
+  # When the container is attached to additional Docker networks, the kernel
+  # may route VM traffic out of any of them depending on destination. Without
+  # a MASQUERADE rule on each, packets leave with the VM's bridge-local source
+  # IP and get dropped by the peer. Add MASQUERADE for every extra external
+  # interface so cross-network reachability is not silently broken.
+  local path extra
+  for path in /sys/class/net/*; do
+    extra=$(basename "$path")
+    [ "$extra" = "lo" ] && continue
+    [ "$extra" = "$VM_NET_DEV" ] && continue
+    [ "$extra" = "$VM_NET_BRIDGE" ] && continue
+    [ "$extra" = "$VM_NET_TAP" ] && continue
+    [ -z "$(ip -4 -o addr show dev "$extra" scope global 2>/dev/null)" ] && continue
+    iptables -t nat -A POSTROUTING -o "$extra" -j MASQUERADE > /dev/null 2>&1 || :
+  done
+
   # shellcheck disable=SC2086
   if ! iptables -t nat -A PREROUTING -i "$VM_NET_DEV" -d "$IP" -p tcp${exclude} -j DNAT --to "$ip"; then
     warn "failed to configure IP tables!" && return 1


### PR DESCRIPTION
# fix: MASQUERADE every attached network in NAT mode

## Problem

When the container is attached to more than one Docker network, VM traffic
destined for anything that isn't reachable via the single interface
`getInfo()` picked can leave the container un-NATed with the VM's
bridge-local source IP (`172.30.0.x`), and be dropped by the peer.

Concrete symptom: in NAT mode (the default), with two attached Docker
networks, the VM cannot reach a peer container on the secondary network, and
any traffic the kernel happens to route out the secondary interface dies.
Single-network setups are unaffected.

## Root cause

`configureNAT()` in `src/network.sh` only installs a single
`iptables -t nat -A POSTROUTING -o "$VM_NET_DEV" -j MASQUERADE` rule — scoped
to the one interface selected by `getInfo()`. Any other interface the
container owns (extra attached Docker networks) has no MASQUERADE, so the
kernel's routing decisions on those interfaces silently leak the VM's source
IP.

## Fix

After the existing primary-interface MASQUERADE, iterate `/sys/class/net/*`
and install a MASQUERADE rule for every other interface that has an IPv4
address, skipping `lo`, the internal bridge (`$VM_NET_BRIDGE`, default
`docker`), and the VM tap (`$VM_NET_TAP`, default `qemu`). Stray MASQUERADE
rules that don't match any traffic are inert, so this is a no-op for the
single-network case.

No changes to DNAT rules (those correctly stay scoped to the published-port
ingress interface) or to user-mode / passt / slirp / DHCP-macvtap modes.

Diff is ~16 lines in `src/network.sh:563`.

## Reproduction / test plan

New under `examples/multi-network-bug/`:

- `01-single-network/compose.yml` — baseline, one network
- `02-external-network/compose.yml` — one externally-created bridge
- `03-two-networks/compose.yml` — two attached bridges (reproduces the bug)
- `verify.sh` — host-side verification script
- `README.md`

`verify.sh` brings up the compose file, waits for in-container networking
to initialise, then checks via `docker exec`:

1. Which interface `getInfo()` picked (from the `DEBUG=Y` log line).
2. That the detected interface holds the default route inside the container.
3. That a `MASQUERADE` rule exists on the detected interface.
4. That **every** external interface (not `lo`, not `docker`, not `qemu`) has
   a `MASQUERADE` rule.

It deliberately does **not** depend on the guest booting far enough to DHCP,
because `BOOT=alpine` drops to a login prompt — the defect lives at the
iptables layer, where the script looks directly.

### Run it

```sh
cd examples/multi-network-bug
./verify.sh 01-single-network
./verify.sh 02-external-network
./verify.sh 03-two-networks
```

Set `IMAGE=<your-image>` to point at a locally-built image with this fix
applied — e.g. `IMAGE=qemu-multinet-fix:local ./verify.sh 03-two-networks`.

### Results

| Case                  | Stock `qemux/qemu` | This PR |
| --------------------- | ------------------ | ------- |
| `01-single-network`   | PASS (4/4)         | PASS (4/4) |
| `02-external-network` | PASS (4/4)         | PASS (4/4) |
| `03-two-networks`     | **FAIL (3/4)**     | PASS (4/4) |

The failing check on stock for case 3 is: `no MASQUERADE rule on: eth1 (VM
traffic routed via these will leak un-NATed)`.

### Live end-to-end proof (case 3, with fix)

```
# simulating VM-sourced ping to peer on netB (was 100% loss on stock):
$ docker exec qemu-multinet-repro ping -c2 -I 172.30.0.1 172.29.0.1
2 packets transmitted, 2 received, 0% packet loss

# simulating VM-sourced ping to public internet:
$ docker exec qemu-multinet-repro ping -c2 -I 172.30.0.1 1.1.1.1
2 packets transmitted, 2 received, 0% packet loss
```

## CI

`shellcheck` (with the repo's existing `SHELLCHECK_OPTS`) passes on both
`src/network.sh` and `examples/multi-network-bug/verify.sh`. No functional
CI job is added: GitHub Actions runners do not expose `/dev/kvm`, so
`verify.sh` cannot be driven there without nested-virtualisation-capable
runners. Suggested follow-up.

## Prior art

Related but distinct: issue #964 (already closed) identified a
source-IP-overlap problem on the **ingress** path and was fixed by adding a
MASQUERADE on the internal `docker` bridge. This PR addresses the
symmetrically-overlooked **egress** path across multiple attached Docker
networks. No currently-open issue tracks this behaviour.
