### PR TITLE
fix: Memory balloon copilot review

### DIFF
--- a/src/balloon.py
+++ b/src/balloon.py
@@ -609,6 +609,18 @@ class BalloonMonitor:
         _, host_available, _ = host_info
         await self._handle_pi_control(qmp, host_available, target_max)
 
+    async def _loop_wait(self, timeout) -> None:
+        futures = (
+            asyncio.create_task(self._stop.wait()),
+            asyncio.create_task(self._cgroup_event.wait())
+        )
+        try:
+            await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED, timeout=timeout)
+        finally:
+            for future in futures:
+                future.cancel()
+            await asyncio.gather(*futures, return_exceptions=True)
+
     async def start(self) -> None:
         log.debug("Starting QEMU Memory Balloon Monitor")
         log.debug("QMP socket: %s", self.args.qmp_sock)
@@ -660,13 +672,7 @@ class BalloonMonitor:
                     else:
                         log.error("Unexpected error in main loop: %s", e, exc_info=e)
                 self._cgroup_event.clear()
-                try:
-                    await asyncio.wait_for(
-                        asyncio.wait({asyncio.ensure_future(self._stop.wait()), asyncio.ensure_future(self._cgroup_event.wait())}, return_when=asyncio.FIRST_COMPLETED),
-                        timeout=self.args.interval,
-                    )
-                except asyncio.TimeoutError:
-                    pass
+                await self._loop_wait(self.args.interval)
         except Exception as e:
             log.error("Error while waiting: %s", e, exc_info=e)
         finally:

--- a/src/balloon.py
+++ b/src/balloon.py
@@ -429,7 +429,7 @@ class BalloonMonitor:
                 c_limit // (1024**2),
                 c_used // (1024**2),
                 c_cache // (1024**2),
-                guest_mem_rss // (1024**2)  if guest_mem_rss is not None else None,
+                guest_mem_rss // (1024**2) if guest_mem_rss is not None else -1,
                 c_overhead // (1024**2),
             )
             
@@ -487,7 +487,7 @@ class BalloonMonitor:
                     log.debug(
                         "Guest RAM usage: %dMB (balloon working mode: reserve-memory; fallback; rss: %dMB/%dMB, stats: %dMB/%dMB)",
                         guest_ram_usage // (1024 ** 2),
-                        guest_mem_rss // (1024 ** 2) if guest_mem_rss is not None else None,
+                        guest_mem_rss // (1024 ** 2) if guest_mem_rss is not None else -1,
                         self.max_mem // (1024 ** 2),
                         guest_stats_mem_used // (1024 ** 2),
                         guest_stats_mem_total // (1024 ** 2),

--- a/src/balloon.py
+++ b/src/balloon.py
@@ -255,7 +255,7 @@ async def qmp_get_guest_ram_stats(qmp: QMPClient) -> Optional[Tuple[int, int, Op
         free_mem = _qmp_int(stats.get("stat-free-memory", -1))
         cache_mem = _qmp_int(stats.get("stat-disk-caches", -1))
         if free_mem >= 0 and cache_mem >= 0:
-            return free_mem - cache_mem, tot_mem, last_update
+            return free_mem + cache_mem, tot_mem, last_update
     return None
 
 async def qmp_get_memory_dev(qmp: QMPClient) -> Optional[list[Dict[str, Any]]]:

--- a/src/balloon.py
+++ b/src/balloon.py
@@ -297,8 +297,7 @@ class BalloonMonitor:
         self._cgroup_event = asyncio.Event()
         self._inotify_fd: int = -1
         self._inotify_wd: int = -1
-        with args.qemu_pid_file as f:
-            self.qemu_pid = int(f.read().strip())
+        self.qemu_pid: int = -1
 
     def _setup_cgroup_watch(self) -> None:
         path = next((p for p in ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory/memory.limit_in_bytes") if os.path.exists(p)), None)
@@ -624,12 +623,24 @@ class BalloonMonitor:
     async def start(self) -> None:
         log.debug("Starting QEMU Memory Balloon Monitor")
         log.debug("QMP socket: %s", self.args.qmp_sock)
-        log.debug("QMP pid: %s", self.qemu_pid)
         log.debug("PSI Pressure threshold: >=%.2f%% (max: %.2f%%)", self.args.psi_pressure, self.args.psi_pressure_max)
         log.debug("Host RAM threshold: %.2f%% (hard: %.2f%%)", self.args.ram_threshold, self.args.ram_threshold_hard)
         log.debug("Adaptive PI Kp: %.4f", self.args.kp)
         log.debug("Adaptive PI Ki: %.4f", self.args.ki)
         log.debug("Polling every %ds", self.args.interval)
+
+        if not os.path.exists(self.args.qemu_pid_file):
+            log.critical("Qemu pid file does not exists: %s", self.args.qemu_pid_file)
+            sys.exit(1)
+
+        with open(self.args.qemu_pid_file, 'r') as f:
+            try:
+                self.qemu_pid = int(f.read().strip())
+            except:
+                log.critical("Qemu pid file malformed or cannot be read", exc_info=True)
+                sys.exit(1)
+
+        log.debug("QMP pid: %s", self.qemu_pid)
 
         host_info = get_host_ram_info()
         if not host_info:
@@ -694,7 +705,7 @@ def main() -> None:
 
     parser.add_argument("--qmp-sock", type=str, required=True,
                         help="Path to QEMU QMP Unix socket")
-    parser.add_argument("--qemu-pid-file", type=argparse.FileType('r'), required=True,
+    parser.add_argument("--qemu-pid-file", type=str, required=True,
                         help="Path to QEMU PID file")
     parser.add_argument("--min-mem", type=byte_size_or_fraction, default="33%",
                         help="Minimum VM memory as a percentage of max (e.g. 33%%) or absolute "


### PR DESCRIPTION
This PR fix following issues reported by Copilot (from https://github.com/qemus/qemu/pull/1012#issuecomment-4574506432):

**22**. %d format specifier used with a potentially None argument Line 432:

```python
log.debug(
    "Container cap: …guest_rss=%dMB…",
    …
    guest_mem_rss // (1024**2) if guest_mem_rss is not None else None,   # ← None
    …
)
```

Python's logging module will raise a TypeError internally when it tries to format None with %d, replacing the debug message with an error log. Same pattern at lines 488–493.

**23.** Guest available memory can be calculated as negative Lines 256–258:

```python
free_mem = _qmp_int(stats.get("stat-free-memory", -1))
cache_mem = _qmp_int(stats.get("stat-disk-caches", -1))
if free_mem >= 0 and cache_mem >= 0:
    return free_mem - cache_mem, tot_mem, last_update
```

Under memory pressure cache_mem can exceed free_mem, yielding a negative "available" value. That negative value propagates into the PI controller as guest_stats_mem_used = tot_mem - negative = a value larger than tot_mem, leading to a balloon that is inflated far beyond needed.

**24.** Wrong sign in guest available memory calculation (logic error) stat-free-memory already excludes cache (it is pure free pages). stat-disk-caches is reclaimable cache. The correct "available" value is free_mem + cache_mem, not free_mem - cache_mem. Subtracting cache from free gives a value that is even smaller than "pure free", not an approximation of stat-available-memory.

**25.** asyncio.ensure_future tasks are never cancelled after asyncio.wait Lines 664–668:

```python
await asyncio.wait_for(
    asyncio.wait({asyncio.ensure_future(self._stop.wait()),
                  asyncio.ensure_future(self._cgroup_event.wait())},
                 return_when=asyncio.FIRST_COMPLETED),
    timeout=self.args.interval,
)
```

On each iteration a new pair of futures is created and passed to asyncio.wait. The pending (losing) future is not cancelled; it accumulates every loop iteration as a dormant but un-GC'd task, creating a memory/resource leak over long runtimes. Should use asyncio.create_task and explicitly cancel the pending task.

**26.** QMP PID file read inside __init__ before QEMU starts

```python
with args.qemu_pid_file as f:
    self.qemu_pid = int(f.read().strip())
```

balloon.sh waits for the PID file to appear, but the file open happens at object construction before asyncio.run(monitor.start()). If the file is empty or malformed at that instant, int(f.read().strip()) raises a ValueError with no useful error message.

**27.** argparse.FileType('r') opens the PID file at parse time and holds the handle

```python
parser.add_argument("--qemu-pid-file", type=argparse.FileType('r'), …)
```

argparse.FileType opens the file immediately during parse_args(). If QEMU terminates and the PID file is deleted before __init__ runs, a stale open handle refers to a deleted file. More subtly, the file handle is left open after __init__ reads from it (no explicit .close()).