### PR TITLE
Fix dnsmasq startup failure: DHCP option 26 is named "mtu", not "interface-mtu"

### DIFF
--- a/src/network.sh
+++ b/src/network.sh
@@ -441,7 +441,7 @@ configureDNS() {
 
     # Set MTU through DHCP option 26
     if [[ "$GUEST_MTU" != "0" && "$GUEST_MTU" != "1500" ]]; then
-      arguments+=" --dhcp-option=option:interface-mtu,$GUEST_MTU"
+      arguments+=" --dhcp-option=option:mtu,$GUEST_MTU"
     fi
 
   fi


### PR DESCRIPTION
## Problem

When the container interface MTU is anything other than 1500 (or 0), `configureDNS()` adds `--dhcp-option=option:interface-mtu,$GUEST_MTU` to the dnsmasq arguments. dnsmasq does not recognize that option name and refuses to start:

```
❯ Host: 10.42.210.11/32 (qemu-windows-2022-statefulset-0)  |  Gateway: 169.254.1.1  |  MTU: 1450  |  DNS: 10.43.0.10
dnsmasq: bad command line options: bad dhcp-option
❯ ERROR: Failed to start Dnsmasq, reason: 1
❯ Warning: failed to setup NAT networking, falling back to user-mode networking!
```

NAT setup then fails and the container falls back to user-mode (passt) networking, which only forwards the explicitly configured ports and has lower throughput.

## Root cause

dnsmasq's name for DHCP option 26 is **`mtu`** — `interface-mtu` is the ISC dhcpd name for the same option, which dnsmasq rejects. See the option table in dnsmasq's `dhcp-common.c` (or `dnsmasq --help dhcp`), where option 26 is listed as `mtu`.

Easy to reproduce (dnsmasq 2.91):

```
$ dnsmasq --test --dhcp-option=option:interface-mtu,1450
dnsmasq: bad command line options: bad dhcp-option

$ dnsmasq --test --dhcp-option=option:mtu,1450
dnsmasq: syntax check OK.
```

The bug is invisible on typical Docker hosts because the branch is skipped when the MTU is 1500. It triggers on any network with a smaller MTU — e.g. Kubernetes CNIs with VXLAN overlays (Calico/flannel, MTU 1450), WireGuard (1420), or PPPoE uplinks. Introduced in #667.

## Fix

One-line change: use dnsmasq's option name `mtu`. The emitted DHCP option on the wire is the same option 26, so guests still receive the intended interface MTU — and now dnsmasq actually starts and NAT mode works on non-1500-MTU networks.

Tested on a Kubernetes cluster (Calico VXLAN, MTU 1450) where the current image reproducibly fails: with this patch dnsmasq starts, NAT networking comes up, and the Windows guest receives MTU 1450 via DHCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)